### PR TITLE
chore: remove useless 'use client' directive

### DIFF
--- a/src/components/ui/date-picker-with-presets.jsx
+++ b/src/components/ui/date-picker-with-presets.jsx
@@ -1,5 +1,3 @@
-"use client"
-
 import React, { useState } from "react"
 import { addDays, format } from "date-fns"
 import { CalendarIcon } from 'lucide-react'

--- a/src/components/ui/tooltip.jsx
+++ b/src/components/ui/tooltip.jsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import { Tooltip as TooltipPrimitive } from "radix-ui"
 


### PR DESCRIPTION
This directive is only applicable to Next.js and other frameworks that implement React Server Components. It's not applicable to a 100% SPA application.