### PR TITLE
refactor: use import.meta.env.DEV instead of custom env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 VITE_NODE_RED_URL=http://localhost:1880
 VITE_BASE_URL=http://localhost:3001/api/v1
-VITE_NODE_ENV=development
 VITE_GRAFANA_URL=http://localhost:3100

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Create a `.env` file in the root directory with the following content:
 VITE_API_BASE_URL=http://localhost:3001/api/v1
 VITE_NODE_RED_URL=http://localhost:1880
 VITE_GRAFANA_URL=http://localhost:3100
-VITE_NODE_ENV=development
 ```
 
 ## Running the Application

--- a/src/pages/app/catalog/CatalogWizard.jsx
+++ b/src/pages/app/catalog/CatalogWizard.jsx
@@ -10,7 +10,7 @@ import { CatalogInfoStep } from '@/components/catalog/CatalogInfoStep';
 import { CatalogControlsStep } from '@/components/catalog/CatalogControlsStep';
 import { CatalogDashboardStep } from '@/components/catalog/CatalogDashboardStep';
 
-const VITE_NODE_ENV = import.meta.env.VITE_NODE_ENV || 'production';
+const isDev = !!import.meta.env.DEV;
 
 const steps = [
   { id: 'info', title: 'Catalog Information' },
@@ -297,7 +297,7 @@ export function CatalogWizard() {
         </Button>
         
         {/* This button is just for manual navigation during development */}
-        {VITE_NODE_ENV === 'development' && (
+        {isDev && (
           <Button
             onClick={goToNextStep}
             disabled={loading || currentStep === steps.length - 1}


### PR DESCRIPTION
With this change, we are using Vite's documented way to detect if we're running in development mode or in production, instead of custom logic around it