### PR TITLE
feat(auth): refresh accessToken and retry ops on failure

### DIFF
--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -11,7 +11,12 @@ export const apiClient = {
    * @returns {Promise} - Promise with the response
    */
   get: (url, params = {}) => {
-    return client.get(url, { params }).then(response => response.data);
+    return client.get(url, { params })
+      .then(response => response.data)
+      .catch(error => {
+        // Spread the error to the caller
+        throw error;
+      });
   },
   
   /**
@@ -21,7 +26,11 @@ export const apiClient = {
    * @returns {Promise} - Promise with the response
    */
   post: (url, data = {}) => {
-    return client.post(url, data).then(response => response.data);
+    return client.post(url, data)
+      .then(response => response.data)
+      .catch(error => {
+        throw error;
+      });
   },
   
   /**
@@ -51,6 +60,10 @@ export const apiClient = {
    * @returns {Promise} - Promise with the response
    */
   delete: (url, data = {}) => {
-    return client.delete(url, { data }).then(response => response.data);
+    return client.delete(url, { data })
+      .then(response => response.data)
+      .catch(error => {
+        throw error;
+      });
   }
 };

--- a/src/components/auth-provider.jsx
+++ b/src/components/auth-provider.jsx
@@ -5,6 +5,7 @@ import { useStorage } from '@/hooks/use-storage';
 import { apiClient } from '@/api/apiClient';
 import { nodeRedClient } from '@/api/nodeRedClient';
 import { client as axiosClient } from '@/api/axiosClient';
+import { refreshToken } from '@/services/auth';
 import { toast } from 'sonner';
 
 export const AuthProvider = ({ children }) => {
@@ -22,6 +23,13 @@ export const AuthProvider = ({ children }) => {
       delete nodeRedClient.defaults.headers.common['Authorization'];
     }
   }, [nodeRedToken, setNodeToken]);
+
+  // Refresh token on app boot
+  useEffect(() => {
+    void refreshUserToken();
+  // We want to run this effect exclusively on mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const axiosLogoutInterceptor = (error) => {
     // If a 401 error is received, logout the user
@@ -51,6 +59,17 @@ export const AuthProvider = ({ children }) => {
       axiosLogoutInterceptor
     );
   };
+
+  /**
+   * Refreshes the current user's access token
+   */
+  async function refreshUserToken() {
+    if (isAuthenticated) {
+      console.log('Refreshing user token...');
+      const { accessToken } = await refreshToken();
+      setUserData((p) => ({ ...p, accessToken }));
+    }
+  }
 
   /**
    * Logs out the current user

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -25,5 +25,5 @@ export function getUserAuthority() {
  * @returns {Promise} - Promise with the response
  */
 export function refreshToken() {
-  return apiClient.get('/api/refresh');
+  return apiClient.get('/users/auth/refresh');
 }


### PR DESCRIPTION
**Formally untested** because the refresh token functionality is still WIP on backend. However, the REST API path has been updated to reflect the current's most up to date swagger schema https://github.com/statuscompliance/status-backend/blob/develop/src/routes/user.routes.js#L191
I've also tried to think deep down all the use cases for the *retry request* logic, which I think covers everything properly.

--------

This pull request introduces improvements to the authentication flow, including token refresh functionality and enhanced handling of logout scenarios. The key changes involve adding a token refresh mechanism on app boot, implementing a retry queue for failed requests during token refresh, and updating the API endpoint for refreshing tokens.

### Authentication Enhancements:

* **Token Refresh on App Boot**: Added a `refreshUserToken` function and a `useEffect` hook to refresh the user token when the app initializes, ensuring the user session remains valid. (`src/components/auth-provider.jsx`, [src/components/auth-provider.jsxL26-R94](diffhunk://#diff-4e8d1b31bcf19bcbb83d5d62786af62638c063e87358f6195041bb16e8cfbaf2L26-R94))

* **Retry Queue for Failed Requests**: Introduced a closure-based `axiosLogoutInterceptor` to handle failed requests during token refresh. It queues requests, retries them after a successful token refresh, and gracefully handles errors. (`src/components/auth-provider.jsx`, [src/components/auth-provider.jsxL26-R94](diffhunk://#diff-4e8d1b31bcf19bcbb83d5d62786af62638c063e87358f6195041bb16e8cfbaf2L26-R94))

### API Updates:

* **Updated Refresh Token Endpoint**: Changed the `refreshToken` function to use the updated API endpoint `/users/auth/refresh` for token refresh requests. (`src/services/auth.js`, [src/services/auth.jsL28-R28](diffhunk://#diff-ecfc4ed960e754b1fb50fba2eb7fc2e45ac17127f8058a991f84b3098497cd4dL28-R28))