### PR TITLE
refactor: remove legacy-peer-deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /frontend
  
 COPY . .
  
-RUN npm ci --no-audit --legacy-peer-deps && npm run build
+RUN npm ci --no-audit && npm run build
  
 FROM nginx:stable-alpine-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:22.12.0-alpine3.20 AS build
  
 WORKDIR /frontend
- 
+
+# Install deps first to avoid installing dependencies on every code change
+COPY package.json package-lock.json ./
+
+RUN npm ci --no-audit
+
 COPY . .
  
 RUN npm ci --no-audit && npm run build


### PR DESCRIPTION
This should no longer be necessary since we already fixed all the dependency drama