### PR TITLE
refactor: remove outdated TODO comments

### DIFF
--- a/src/components/basic-page.jsx
+++ b/src/components/basic-page.jsx
@@ -96,7 +96,6 @@ export default function Page({ children, ...props }) {
 
   return (
     <div className="h-full space-y-8">
-      {/* TODO: Check why group-has-* class was working before switching to UnoCSS */}
       <header className="group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 h-16 flex shrink-0 items-center gap-2 transition-[width,height] ease-linear">
         <div className="flex items-center gap-2">
           <TooltipProvider>

--- a/src/components/ui/sidebar.jsx
+++ b/src/components/ui/sidebar.jsx
@@ -261,7 +261,6 @@ const SidebarRail = React.forwardRef(({ className, ...props }, ref) => {
 SidebarRail.displayName = "SidebarRail"
 
 const SidebarInset = React.forwardRef(({ className, ...props }, ref) => {
-  // TODO: Investigate why md:peer-data* is not being applied
   return (
     (<main
       ref={ref}
@@ -410,7 +409,6 @@ const SidebarMenuItem = React.forwardRef(({ className, ...props }, ref) => (
 ))
 SidebarMenuItem.displayName = "SidebarMenuItem"
 
-// TODO: Check why group-has* is not being applied correctly
 const sidebarMenuButtonVariants = cva(
   "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
@@ -484,7 +482,6 @@ SidebarMenuButton.displayName = "SidebarMenuButton"
 const SidebarMenuAction = React.forwardRef(({ className, asChild = false, showOnHover = false, ...props }, ref) => {
   const Comp = asChild ? SlotPrimitive.Root : "button"
 
-  // TODO: Check why peer-data class (and many in this area) are not being applied
   return (
     (<Comp
       ref={ref}
@@ -506,7 +503,6 @@ const SidebarMenuAction = React.forwardRef(({ className, asChild = false, showOn
 })
 SidebarMenuAction.displayName = "SidebarMenuAction"
 
-// TODO: Check why peer-data class (and many in this area) are not being applied
 const SidebarMenuBadge = React.forwardRef(({ className, ...props }, ref) => (
   <div
     ref={ref}

--- a/uno.config.js
+++ b/uno.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
       preflight: 'on-demand'
     }),
     /**
-     * TODO: Investigate alternative to this plugin. It's not very well-maintained, as its
+     * TODO: Investigate alternative to this plugin. It's not as maintained as its
      * tailwindcss-animate counterpart
      */
     presetAnimations()


### PR DESCRIPTION
UnoCSS's v66.3 fixed the classes that were recognized with Tailwind but not UnoCSS, so these comments are not needed as well after the merge of #59.

Ref: https://github.com/unocss/unocss/pull/4789