### PR TITLE
chore(deps): remove react 19 override

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,6 @@
   "browserslist": [
     "defaults and fully supports es6-module"
   ],
-  "overrides": {
-    "ahooks": {
-      "react": "^19.0.0"
-    }
-  },
   "dependencies": {
     "@hookform/resolvers": "5.1.1",
     "@tanstack/react-table": "8.21.3",


### PR DESCRIPTION
`ahooks` didn't have React 19 as a peer dependency, despite it being 100% compatiblr with it. To avoid mangling our dependencies and lockfile, I added an override for it.

After the merge of #55, which bumps `ahooks` to v3.9.0, this is no longer necessary since ahooks already fixed this.